### PR TITLE
Feature añadiendo docker-compose para env=dev

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -2,8 +2,7 @@ services:
   #php
   #ngingx
   web_server:
-    build:
-      dockerfile: ./nginx/Dockerfile
+    image: nginx:latest
     ports:
       - "81:80"
     volumes:
@@ -11,13 +10,16 @@ services:
   app:
     build:
       dockerfile: ./php/Dockerfile
-
+    volumes:
+        - ./app:/var/www/html
   #mysql
   db:
     image: mysql:8.0
     volumes:
       - mysqldata:/var/lib/mysql
       #De manera automatica y optimizada, docker va a decidir donde guardar la data
+    ports:
+      - "3306:3306"
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: secret
@@ -26,15 +28,15 @@ services:
       MYSQL_DATABASE: docker_php
       
       #redis
-      #phpmyadmin:
-      #image: phpmyadmin
-      #restart: always
-      #ports:
-      #- "8080:80"
-      #environment:
-      #- PMA_HOST=localhost
-      #- PMA_PORT=3306
-      #- PMA_ARBITRARY=1
+  phpmyadmin:
+    image: phpmyadmin
+    restart: always
+    ports:
+      - "8080:80"
+    environment:
+      - PMA_HOST=localhost
+      - PMA_PORT=3306
+      - PMA_ARBITRARY=1
 
 volumes:
   mysqldata:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+
+COPY ./nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+
+COPY ./app/public /var/www/html/public


### PR DESCRIPTION
Se creo y modificaron archivos para permitir que se tenga cierta configuracion en desarrollo y en produccion distintas.
Para ejecutar el contenedor de dev, se debe escribir:

```docker compose -f docker-compose.dev.yaml --build -d```